### PR TITLE
Make textarea not resizeable

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -165,6 +165,7 @@ textarea {
   padding: 0;
 
   border: none;
+  resize: none;
 
   &:focus {
     color: $grey;


### PR DESCRIPTION
There are these little lines at the bottom right of the text area that probably don't need to be there. This gets rid of them and makes the text area not resizable in the process.
