### PR TITLE
UUIDs for IDs

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,8 @@
 require "message_params"
 
 class MessagesController < ApplicationController
+  before_action :set_message, only: [:show, :download]
+
   def new
     @message = Message.new
   end
@@ -16,14 +18,12 @@ class MessagesController < ApplicationController
   end
 
   def show
-    @message = Message.find_by! slug: params[:slug]
     if @message.file_contents.nil?
       @message.destroy
     end
   end
 
   def download
-    @message = Message.find_by! slug: params[:slug]
     @message.destroy
     send_data(
       @message.read_file,
@@ -34,5 +34,9 @@ class MessagesController < ApplicationController
 
   def message_params
     MessageParams.generate(params.require(:message).permit(:text, :file))
+  end
+
+  def set_message
+    @message = Message.find(params[:id])
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,15 +1,9 @@
 require "message_file"
 
 class Message < ActiveRecord::Base
-  before_save :set_slug
   before_save :set_file_contents, unless: Proc.new { |message| message.file_contents.nil? }
 
   validate :has_text_or_file?
-
-  def set_slug(salt=Time.now, content=rand)
-    self.slug = Digest::MD5.hexdigest("#{salt}:#{content}")
-    self
-  end
 
   def set_file_contents
     self.file_contents = MessageFile.encode(self.file_contents)
@@ -30,6 +24,6 @@ class Message < ActiveRecord::Base
   end
   
   def file_name
-    "#{slug}.#{file_extension}"
+    "#{id}.#{file_extension}"
   end
 end

--- a/app/views/messages/create.html.slim
+++ b/app/views/messages/create.html.slim
@@ -1,4 +1,4 @@
-input id="link" name="link" type="text" value=message_url(@message.slug) readonly=true
+input id="link" name="link" type="text" value="#{message_url(@message)}" readonly=true
 
 coffee:
   elem = document.getElementById "link"

--- a/app/views/messages/show.html.slim
+++ b/app/views/messages/show.html.slim
@@ -5,4 +5,4 @@ p.alert
 
 - unless @message.file_contents.nil?
   - content_for :head do
-    meta http-equiv="refresh" content="1;url=#{download_url(@message.slug)}"
+    meta http-equiv="refresh" content="1;url=#{download_url(@message)}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,7 @@ BurnBox::Application.routes.draw do
 
   get "faq" => "faq#index"
 
-  get "messages/:slug" => "messages#show"
-  get "messages/:slug/download", to: "messages#download", as: "download"
+  get "messages/:id/download", to: "messages#download", as: "download"
   resources :messages
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/db/migrate/20151109001917_remove_paperclip_fields.rb
+++ b/db/migrate/20151109001917_remove_paperclip_fields.rb
@@ -1,7 +1,10 @@
 class RemovePaperclipFields < ActiveRecord::Migration
   def change
-    remove_attachment :messages, :file
     change_table :messages do |t|
+      t.remove :file_file_name
+      t.remove :file_content_type
+      t.remove :file_file_size
+      t.remove :file_updated_at
       t.text :file_contents
       t.string :file_extension
     end

--- a/db/migrate/20151109031907_change_ids_to_uui_ds.rb
+++ b/db/migrate/20151109031907_change_ids_to_uui_ds.rb
@@ -1,0 +1,8 @@
+class ChangeIdsToUuiDs < ActiveRecord::Migration
+  def change
+    change_table :messages do |t|
+      t.remove :id
+      t.uuid :id, primary_key: true, default: "uuid_generate_v4()"
+    end
+  end
+end

--- a/db/migrate/20151109031907_change_ids_to_uui_ds.rb
+++ b/db/migrate/20151109031907_change_ids_to_uui_ds.rb
@@ -1,5 +1,6 @@
 class ChangeIdsToUuiDs < ActiveRecord::Migration
   def change
+    enable_extension "uuid-ossp"
     change_table :messages do |t|
       t.remove :id
       t.uuid :id, primary_key: true, default: "uuid_generate_v4()"

--- a/db/migrate/20151110012641_drop_slugs.rb
+++ b/db/migrate/20151110012641_drop_slugs.rb
@@ -1,0 +1,6 @@
+class DropSlugs < ActiveRecord::Migration
+  def change
+    Message.destroy_all("slug IS NOT NULL")
+    remove_column :messages, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151109031907) do
+ActiveRecord::Schema.define(version: 20151110012641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "uuid-ossp"
@@ -19,7 +19,6 @@ ActiveRecord::Schema.define(version: 20151109031907) do
 
   create_table "messages", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string "text",           limit: 255
-    t.string "slug",           limit: 255
     t.text   "file_contents"
     t.string "file_extension"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151109001917) do
+ActiveRecord::Schema.define(version: 20151109031907) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "uuid-ossp"
   enable_extension "plpgsql"
 
-  create_table "messages", force: :cascade do |t|
-    t.string "text"
-    t.string "slug"
+  create_table "messages", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.string "text",           limit: 255
+    t.string "slug",           limit: 255
     t.text   "file_contents"
     t.string "file_extension"
   end

--- a/features/step_definitions/tmwsd_steps.rb
+++ b/features/step_definitions/tmwsd_steps.rb
@@ -18,7 +18,7 @@ When /^I create a message$/ do
 end
 
 When /^I go to that message's page$/ do
-  visit message_path @message.slug
+  visit message_path(@message)
 end
 
 Then /^I should see the message$/ do
@@ -26,10 +26,10 @@ Then /^I should see the message$/ do
 end
 
 Then /^I should see the file$/ do
-  url = download_url @message.slug
+  url = download_url(@message)
 
   expect(page.body).to include(url)
-  visit download_path(@message.slug)
+  visit url
 end
 
 Then /^the message should deleted$/ do
@@ -37,7 +37,7 @@ Then /^the message should deleted$/ do
 end
 
 Then /^I should see the message URL$/ do
-  expect(page).to have_field("link", with: message_url(Message.first.slug))
+  expect(page).to have_field("link", with: message_url(Message.first))
 end
 
 When /^I create a message with a file$/ do

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -30,14 +30,14 @@ describe MessagesController do
   end
 
   describe "showing messages" do
-    let(:message) { Message.new(id: 1, text: "secret message") }
+    let(:message) { Message.new(text: "secret message") }
 
     before do
-      allow(Message).to receive(:find_by!).with(slug: "1") { message }
+      allow(Message).to receive(:find).with("1b0dad15-732e-45cc-8da4-749b4b21585d") { message }
     end
 
     it "shows an existing message" do
-      get :show, slug: "1"
+      get :show, id: "1b0dad15-732e-45cc-8da4-749b4b21585d"
 
       expect(assigns :message).to eq message
     end
@@ -46,30 +46,36 @@ describe MessagesController do
       allow(message).to receive(:file_contents) { nil }
       expect(message).to receive(:destroy)
 
-      get :show, slug: "1"
+      get :show, id: "1b0dad15-732e-45cc-8da4-749b4b21585d"
     end
 
     it "doesn't delete messages with files after rendering" do
       allow(message).to receive(:file_contents) { "foo" }
       expect(message).to_not receive(:destroy)
 
-      get :show, slug: "1"
+      get :show, id: "1b0dad15-732e-45cc-8da4-749b4b21585d"
     end
   end
 
   describe "downloading a file" do
-    let(:message) { Message.new(id: 1, file_contents: "c2VjcmV0IG1lc3NhZ2U=\n", file_extension: "txt", slug: "123") }
+    let(:message) do
+      Message.new(
+        id: "1b0dad15-732e-45cc-8da4-749b4b21585d",
+        file_contents: "c2VjcmV0IG1lc3NhZ2U=\n",
+        file_extension: "txt",
+      )
+    end
 
     before do
-      allow(Message).to receive(:find_by!).with(slug: "1") { message }
+      allow(Message).to receive(:find).with("1b0dad15-732e-45cc-8da4-749b4b21585d") { message }
     end
 
     it "sends a file" do
-      expect(controller).to receive(:send_data).with("secret message", type: "text/plain", filename: "123.txt")
+      expect(controller).to receive(:send_data).with("secret message", type: "text/plain", filename: "1b0dad15-732e-45cc-8da4-749b4b21585d.txt")
       expect(message).to receive(:destroy)
 
       # the view throws an error because we stub out send_file
-      expect{ get :download, slug: "1"}.to raise_error ActionView::MissingTemplate 
+      expect{ get :download, id: "1b0dad15-732e-45cc-8da4-749b4b21585d"}.to raise_error ActionView::MissingTemplate 
     end
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,36 +1,23 @@
 require "rails_helper"
 
 describe Message do
-  it "sets a slug" do
-    message = Message.new.set_slug "abc", 1
-
-    expect(message.slug).to eq "7faac3319aba94a00596f1e271d9da82"
-  end
-
-  it "sets the slug on save" do
-    message = Message.new text: "test"
-    expect(message).to receive(:set_slug)
-
-    message.save
-  end
-
   it "does not set the file contents when nil" do
-    message = Message.new(text: "test")
+    message = Message.new(id: "1b0dad15-732e-45cc-8da4-749b4b21585d", text: "test")
     expect(message).to_not receive(:set_file_contents)
 
     message.save
   end
 
   it "sets the file contents on save" do
-    message = Message.new(file_contents: "foo bar")
+    message = Message.new(id: "1b0dad15-732e-45cc-8da4-749b4b21585d", file_contents: "foo bar")
     expect(message).to receive(:set_file_contents)
 
     message.save
   end
 
   it "validates that at either text or file are present" do
-    expect(Message.new text: "test").to be_valid
-    expect(Message.new file_contents: "foo bar").to be_valid
+    expect(Message.new(text: "test")).to be_valid
+    expect(Message.new(file_contents: "foo bar")).to be_valid
     expect(Message.new).to_not be_valid
   end
 
@@ -42,10 +29,9 @@ describe Message do
     expect(Message.new(file_extension: "txt").file_mime_type).to eq "text/plain"
   end
 
-  it "generates a filename from the slug and extension" do
-    message = Message.new(file_extension: "txt")
-    message.set_slug("abc", 1)
+  it "generates a filename from the id and extension" do
+    message = Message.new(id: "1b0dad15-732e-45cc-8da4-749b4b21585d", file_extension: "txt")
 
-    expect(message.file_name).to eq "7faac3319aba94a00596f1e271d9da82.txt"
+    expect(message.file_name).to eq "1b0dad15-732e-45cc-8da4-749b4b21585d.txt"
   end
 end

--- a/spec/routing/messages_routing_spec.rb
+++ b/spec/routing/messages_routing_spec.rb
@@ -5,15 +5,15 @@ describe "messages routes" do
     expect(get "/messages/123").to route_to(
       controller: "messages",
       action: "show",
-      slug: "123"
+      id: "123"
     )
   end
 
-  it "routes slugs to messages#download" do
+  it "routes IDs to messages#download" do
     expect(get "/messages/123/download").to route_to(
       controller: "messages",
       action: "download",
-      slug: "123"
+      id: "123"
     )
   end
 end

--- a/spec/views/messages/create_spec.rb
+++ b/spec/views/messages/create_spec.rb
@@ -1,16 +1,15 @@
 require "rails_helper"
 
 describe "messages/create" do
-  let(:message) { Message.new text: "This is a test" }
+  let(:message) { Message.new(id: "1b0dad15-732e-45cc-8da4-749b4b21585d", text: "This is a test") }
 
   before do
-    message.set_slug
     assign :message, message
 
     render
   end
 
   it "displays the link" do
-    expect(rendered).to have_field("link", with: message_url(message.slug))
+    expect(rendered).to have_field("link", with: message_url(message))
   end
 end

--- a/spec/views/messages/show_spec.rb
+++ b/spec/views/messages/show_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
 describe "messages/show" do
-  let(:message) { Message.new(id: 1, text: "This is a test") }
+  let(:message) { Message.new(id: "1b0dad15-732e-45cc-8da4-749b4b21585d", text: "This is a test") }
 
   before do
-    message.set_slug
     assign :message, message
 
     render
@@ -23,10 +22,10 @@ describe "messages/show" do
   end
 
   context "when the message has a file" do
-    let(:message) { Message.new(id: 2, file_contents: "foo bar") }
+    let(:message) { Message.new(id: "1b0dad15-732e-45cc-8da4-749b4b21585d", file_contents: "foo bar") }
 
     it "inserts the meta tag if the message has a file" do
-      expect(view.content_for(:head)).to include(download_url(message.slug))
+      expect(view.content_for(:head)).to include(download_url(message))
     end
   end
 end


### PR DESCRIPTION
Instead of custom, potentially information-leaking code, to generate slugs and perform look ups on slugs, let's use UUIDs as default IDs and let Rails do its normal thing.

One interesting thing to note is that while there are several ways to generate UUIDs---some methods even sequential, others that use MAC addresses---the method we're using is version 4, which is intended to be random and should, thus, not leak any information about the contents or author of the messages.